### PR TITLE
Enable improved give paint bottle command

### DIFF
--- a/src/net/aegistudio/mpp/MapPainting.java
+++ b/src/net/aegistudio/mpp/MapPainting.java
@@ -15,6 +15,7 @@ import net.aegistudio.mpp.factory.NormalSubCommand;
 import net.aegistudio.mpp.foreign.PluginCanvasManager;
 import net.aegistudio.mpp.foreign.PluginCommandManager;
 import net.aegistudio.mpp.paint.PaintManager;
+import net.aegistudio.mpp.paint.GivePaintBottleCommand;
 import net.aegistudio.mpp.paint.MixPaintBottleCommand;
 import net.aegistudio.mpp.tool.*;
 import net.milkbowl.vault.economy.Economy;
@@ -154,6 +155,7 @@ public class MapPainting extends JavaPlugin {
             //this.control = new ControlCommand();
             //this.command.add("control", this.control); // dont need control do we?
             this.m_commandHandler.add("buy", new MixPaintBottleCommand());
+            this.m_commandHandler.add("give", new GivePaintBottleCommand());
             //this.command.add("purge", new PurgeCanvasCommand());
             
             // changes to match preferred syntax

--- a/src/net/aegistudio/mpp/paint/GivePaintBottleCommand.java
+++ b/src/net/aegistudio/mpp/paint/GivePaintBottleCommand.java
@@ -1,42 +1,123 @@
 
 package net.aegistudio.mpp.paint;
 
-import org.bukkit.Bukkit;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
-
+import net.aegistudio.mpp.CommandHandle;
 import net.aegistudio.mpp.MapPainting;
+import java.awt.Color;
 
-import java.awt.*;
 
-
-public class GivePaintBottleCommand implements CommandExecutor {
+/**
+ * Handler responsible for giving a specific player a specific paint color. 
+ * Does not consume anything and is a direct "give".
+ */
+public class GivePaintBottleCommand implements CommandHandle {
 	
+	private static final String redFormat 						= "\u00A74";
 	
-    public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
+    public static final String PERMISSION_NODE					= "mpp.command.give.player.paint.bottle";
+    public static final String PERMISSION_NODE_FAIL_TOKEN 		= "@mpp.common.permission.fail";
+    public static final String PERMISSION_NODE_FAIL_INVARIANT 	= redFormat + "You don't have permission to execute this command."; 
+    public String noPermission 									= PERMISSION_NODE_FAIL_INVARIANT;
+    
+    public static final String RGB_INVALID_TOKEN 				= "@mpp.common.rgb.invalid";
+    public static final String RGB_INVALID_INVARIANT 			= redFormat + "The RGB values provided were invalid."; 
+    public String rgbInvalid 									= RGB_INVALID_INVARIANT;
+    
+    public static final String PLAYER_OFFLINE_TOKEN 			= "@mpp.common.player.offline";
+    public static final String PLAYER_OFFLINE_INVARIANT 		= redFormat + " is offline."; 
+    public String playerOffline 								= PLAYER_OFFLINE_INVARIANT;
+    
+    public static final String INVENTORY_FULL_TOKEN 			= "@mpp.common.player.inventory.full";
+    public static final String INVENTORY_FULL_INVARIANT 		= redFormat + " has no free inventory space."; 
+    public String noInventory 									= INVENTORY_FULL_INVARIANT;
+    
+    public static final String USAGE_GUIDE_TOKEN 				= "@mpp.command.give.player.paint.bottle.usage";
+    public static final String USAGE_GUIDE_INVARIANT 			= "Usage: /paint give <player> <red> <green> <blue>"; 
+    public String usageGuide 									= USAGE_GUIDE_INVARIANT;
+    
+    public static final String DESCRIPTION_TOKEN 				= "@mpp.command.give.player.paint.bottle.description";
+    public static final String DESCRIPTION_INVARIANT 			= "Gives a player a specific paint bottle color."; 
+    public String description 									= DESCRIPTION_INVARIANT;
+    
+    public static final String SUCCESS_TOKEN 					= "@mpp.command.give.player.paint.bottle.success";
+    public static final String SUCCESS_INVARIANT 				= " recieved paint bottle color "; 
+    public String success										= SUCCESS_INVARIANT;
+
+
+    /**
+     * Run when initially loaded, checks localization for all strings involved.
+     */
+	@Override
+	public void load(MapPainting plugin, ConfigurationSection config) throws Exception {
+		plugin.getLocale(PERMISSION_NODE_FAIL_TOKEN, PERMISSION_NODE_FAIL_INVARIANT, config);
+		plugin.getLocale(RGB_INVALID_TOKEN, RGB_INVALID_INVARIANT, config);
+		plugin.getLocale(PLAYER_OFFLINE_TOKEN, PLAYER_OFFLINE_INVARIANT, config);
+		plugin.getLocale(INVENTORY_FULL_TOKEN, INVENTORY_FULL_INVARIANT, config);
+		plugin.getLocale(USAGE_GUIDE_TOKEN, USAGE_GUIDE_INVARIANT, config);
+		plugin.getLocale(DESCRIPTION_TOKEN, DESCRIPTION_INVARIANT, config);
+		plugin.getLocale(SUCCESS_TOKEN, SUCCESS_INVARIANT, config);
+	}
+
+	
+	/**
+     * Mandatory override
+     */
+	@Override
+	public void save(MapPainting plugin, ConfigurationSection config) throws Exception {
+	}
+
+	
+	/**
+     * Description for this command when detailing it in command lists.
+     */
+	@Override
+	public String description() {
+		return description;
+	}
+
+	
+	/**
+     * Handler for the /paint give command.
+     * Gives a specific player a bottle of paint of a particular color.
+     * @param plugin - Reference to the invoking plugin.
+     * @param prefix - The command prefix /paint give.
+     * @param sender - The command invoker, can be the console window.
+     * @param args[] - Array of space separated arguments passed with the command
+     * @return true.
+     */
+	@Override
+	public boolean handle(MapPainting plugin, String prefix, CommandSender sender, String[] args) {
     	
     	// Guard against insufficient permissions to forcibly give a paint bottle
-        if (!sender.hasPermission("palette.command")) {
-            sender.sendMessage("\u00a7cYou don't have permission to execute this command.");
+        if (!sender.hasPermission(PERMISSION_NODE)) {
+            sender.sendMessage(noPermission);
             return true;
         }
         
         // Guard against too few arguments to generate a bottle
-        if (args.length < 4) {
-            sender.sendMessage("\u00a7cUsage: /palette <player> <red> <green> <blue> <optional: amount>");
+        if (args.length != 4) {
+            sender.sendMessage(usageGuide);
             return true;
         }
         
         // Guard against giving items to offline players
-        Player player = Bukkit.getPlayer(args[0]);
+        String playerName = args[0];
+        Player player = plugin.getServer().getPlayer(playerName);
         if (player == null) {
-            sender.sendMessage("\u00a7cThis player is offline.");
+            sender.sendMessage(args[0] + playerOffline);
             return true;
         }
         
-        // Guard against invalid channel values
+        // Guard against no inventory space to receive the paint bottle
+        if (player.getInventory().firstEmpty() == -1){
+        	sender.sendMessage(playerName + noInventory);
+        	return true;
+        }
+        
+        // Guard against argument casts not being valid (ie it's a string rather than a number)
         int red;
         int green;
         int blue;
@@ -46,41 +127,38 @@ public class GivePaintBottleCommand implements CommandExecutor {
             blue = Integer.parseInt(args[3]);
         }
         catch (Exception e) {
-            sender.sendMessage("\u00a7cInvalid number.");
+            sender.sendMessage(rgbInvalid);
             return true;
         }
         
-        // Guard against invalid quantities of bottles
-        int amount = 1;
-        if (args.length >= 5) {
-            try {
-                amount = Integer.parseInt(args[4]);
-            }
-            catch (Exception e) {
-                sender.sendMessage("\u00a7cInvalid number.");
-                return true;
-            }
+        // Guard against bad color range values
+        if (!(isBetween(red, 0, 255) && isBetween(green, 0, 255) && isBetween(blue, 0, 255))) {
+            sender.sendMessage(rgbInvalid);
+            return true;
         }
         
-        if (!(this.isBetween(red, 0, 255) && this.isBetween(green, 0, 255) && this.isBetween(blue, 0, 255))) {
-            sender.sendMessage("\u00a7cRGB values must be between 0 to 255.");
-            return true;
-        }
-        if (amount <= 0) {
-            sender.sendMessage("\u00a7cThe amount must be bigger than 1.");
-            return true;
-        }
-        for (int i = 0; i < amount; ++i) {
-        	MapPainting plugin = (MapPainting)sender.getServer().getPluginManager().getPlugin("MapPaintingRebuild"); 
-        	PaintManager PM = plugin.m_paintManager;
-            player.getInventory().addItem(PM.getPaintBottle(new Color(red, green, blue)));
-        }
-        sender.sendMessage("\u00a7aSuccessfully gave \u00a7e" + player.getName() + "\u00a7a the color.");
+        // Actually give the item
+        PaintManager PM = plugin.m_paintManager;
+        Color color = new Color(red, green, blue);
+        player.getInventory().addItem(PM.getPaintBottle(color));
+        sender.sendMessage(playerName + success + PM.getColorName(color));
+        
         return true;
-    }
 
+	}
+	
+	
+    /**
+     * Checks if a number is inside an expected range 
+     * @param num - int to check
+     * @param min - the lower boundary for success (inclusive)
+     * @param max - the upper boundary for success (inclusive)
+     * @return boolean - if the check value is between the min and max
+     */
     private boolean isBetween(int num, int min, int max) {
         return num >= min && num <= max;
     }
+	
+	
 }
 


### PR DESCRIPTION
## What problem is this PR addressing
The current paint bottle command has been disabled for some time. With the upcoming changes to the buy command becoming more like a "mix" command that uses ingredients, the ability to directly get a paint color when required is ideal.

## How is this PR addressing the problem
Updates the existing paint command that had been disabled for some time.

## What testing has been performed
- [x] Built and installed a release featuring the final change set
- [x] Ran each failure branch and ensured feedback was sensible
- [x] Tested permission node was blocking
- [x] Tested string localization was working correctly
