### PR TITLE
Move common functions to util file

### DIFF
--- a/src/net/aegistudio/mpp/CommandHandle.java
+++ b/src/net/aegistudio/mpp/CommandHandle.java
@@ -1,9 +1,4 @@
-/*
- * Decompiled with CFR 0.145.
- * 
- * Could not load the following classes:
- *  org.bukkit.command.CommandSender
- */
+
 package net.aegistudio.mpp;
 
 import org.bukkit.command.CommandSender;

--- a/src/net/aegistudio/mpp/MapPainting.java
+++ b/src/net/aegistudio/mpp/MapPainting.java
@@ -6,6 +6,7 @@ import net.aegistudio.mpp.canvas.*;
 import net.aegistudio.mpp.color.ColorManager;
 import net.aegistudio.mpp.color.ExpertColorParser;
 import net.aegistudio.mpp.color.RgbColorParser;
+import net.aegistudio.mpp.common.Utils;
 import net.aegistudio.mpp.control.ControlCommand;
 import net.aegistudio.mpp.export.AssetService;
 import net.aegistudio.mpp.export.PluginCanvasService;
@@ -57,7 +58,9 @@ public class MapPainting extends JavaPlugin {
     
     public ConfigurationSection m_configSection;
     public Properties defaultLocale;
-
+    
+    // declare utilities
+    public Utils utils;
     
     public static final ArrayList<String> m_localeStrings = Lists.newArrayList("en");;
     
@@ -139,6 +142,8 @@ public class MapPainting extends JavaPlugin {
         	
         	// register command event handlers
             FileConfiguration config = this.getConfig();
+            
+            this.utils = new Utils(this);
             
             this.m_commandHandler = new CompositeHandle();
             this.m_commandCreateHandler = new CreateCanvasCommand(); // needed to load strings

--- a/src/net/aegistudio/mpp/common/Utils.java
+++ b/src/net/aegistudio/mpp/common/Utils.java
@@ -1,0 +1,213 @@
+package net.aegistudio.mpp.common;
+import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Player;
+import net.aegistudio.mpp.MapPainting;
+import net.aegistudio.mpp.Module;
+import java.awt.Color;
+
+
+public class Utils implements Module {
+
+	// Common references
+	public MapPainting plugin;
+	public ConfigurationSection config;
+	
+	// Formatting strings
+	public static final String redFormat 						= "\u00A74";
+	
+	// Common strings
+    public static final String PERMISSION_NODE_FAIL_TOKEN 		= "@mpp.common.permission.fail";
+    public static final String PERMISSION_NODE_FAIL_INVARIANT 	= redFormat + "You don't have permission to execute this command."; 
+    public String noPermission 									= PERMISSION_NODE_FAIL_INVARIANT;
+    
+    public static final String PLAYER_OFFLINE_TOKEN 			= "@mpp.common.player.offline";
+    public static final String PLAYER_OFFLINE_INVARIANT 		= redFormat + " is offline."; 
+    public String playerOffline 								= PLAYER_OFFLINE_INVARIANT;
+    
+    public static final String PLAYER_ONLY_CMD_TOKEN 			= "@mpp.common.player.only.command";
+    public static final String PLAYER_ONLY_CMD_INVARIANT 		= redFormat + "Only players may execute this command."; 
+    public String playerOnlyCommand 							= PLAYER_ONLY_CMD_INVARIANT;
+    
+    public static final String INVENTORY_FULL_TOKEN 			= "@mpp.common.player.inventory.full";
+    public static final String INVENTORY_FULL_INVARIANT 		= redFormat + " has no free inventory space."; 
+    public String noInventory 									= INVENTORY_FULL_INVARIANT;
+    
+    public static final String RGB_INVALID_TOKEN 				= "@mpp.common.rgb.invalid";
+    public static final String RGB_INVALID_INVARIANT 			= redFormat + "The RGB values provided were invalid."; 
+    public String rgbInvalid 									= RGB_INVALID_INVARIANT;
+    
+    
+	public Utils(MapPainting mapPainting) {
+		plugin = mapPainting;
+	}
+
+
+	@Override
+	public void load(MapPainting plugin, ConfigurationSection config) {
+		
+		// Update references
+		this.config = config;
+		
+		// Localize common strings
+		plugin.getLocale(PERMISSION_NODE_FAIL_TOKEN, PERMISSION_NODE_FAIL_INVARIANT, config);
+		plugin.getLocale(PLAYER_OFFLINE_TOKEN, PLAYER_OFFLINE_INVARIANT, config);
+		plugin.getLocale(INVENTORY_FULL_TOKEN, INVENTORY_FULL_INVARIANT, config);
+		plugin.getLocale(RGB_INVALID_TOKEN, RGB_INVALID_INVARIANT, config);
+		plugin.getLocale(PLAYER_ONLY_CMD_TOKEN, PLAYER_ONLY_CMD_INVARIANT, config);
+		
+	}
+
+
+	@Override
+	public void save(MapPainting plugin, ConfigurationSection config) throws Exception {
+		// TODO Auto-generated method stub
+	}
+    
+    
+    /**
+     * Checks if a player is offline. Performs no validity checks for if playerName is an actual player.
+     * @param playerName - check by name if the player is online.
+     * @param sender - the commandSender to notify if failed
+     * @return boolean - if the player is online
+     */
+    public boolean playerIsOffline(String playerName, CommandSender sender) {
+    	
+        Player player = sender.getServer().getPlayer(playerName);
+        if (player == null) {
+        	sender.sendMessage(playerName + playerOffline);
+            return true;
+        }
+    	return false;    	
+    }
+
+    
+    /**
+     * Checks if a commandSender has a permission node.
+     * @param permissionNode - the node to check
+     * @param sender - the commandSender to check and notify if failed
+     * @param failureMessage - Failure message override (must already be localized by caller)
+     * @return boolean - true if the check fails, false if the player has the permission
+     */
+	public boolean permissionCheckFails(String permissionNode, CommandSender sender, String failureMessage) {
+		
+        if (!sender.hasPermission(permissionNode)) {
+        	sender.sendMessage(failureMessage);
+        	return true;
+        }
+		return false;
+	}
+	
+	
+	/**
+     * Checks if a commandSender has a permission node.
+     * @param permissionNode - the node to check
+     * @param sender - the commandSender to check and notify if failed
+     * @return boolean - true if the check fails, false if the player has the permission
+     */
+	public boolean permissionCheckFails(String permissionNode, CommandSender sender) {
+		return this.permissionCheckFails(permissionNode, sender, noPermission);
+	}
+
+
+	/**
+     * Checks if a command has the right number of parameters (matches expected)
+     * @param expectedCount - the number of args expected
+     * @param args - the command args
+     * @param usageGuide - the feedback to give the sender (ie how to use the command)
+     * @param sender - the commandSender to check and notify if failed
+     * @return boolean - true if the check fails, false if the number of args is correct
+     */
+	public boolean commandHasIncorrectNumberOfArgs(int expectedCount, String[] args, String usageGuide, CommandSender sender) {
+		
+        if (args.length != expectedCount) {
+            sender.sendMessage(usageGuide);
+            return true;
+        }
+		return false;
+	}
+
+
+	/**
+     * Checks if playerName has a free inventory slot.
+     * @param playerName - the player to search for a free inventory slot
+     * @param sender - the commandSender to check and notify if failed
+     * @return boolean - true if the check fails, false if the number of args is correct
+     */
+	public boolean playerHasNoInventorySpace(String playerName, CommandSender sender) {
+		
+        if (plugin.getServer().getPlayer(playerName).getInventory().firstEmpty() == -1){
+        	sender.sendMessage(playerName + noInventory);
+        	return true;
+        }
+		
+		return false;
+	}
+
+
+    /**
+     * Checks if a number is inside an expected range 
+     * @param num - int to check
+     * @param min - the lower boundary for success (inclusive)
+     * @param max - the upper boundary for success (inclusive)
+     * @return boolean - if the check value is between the min and max
+     */
+    public final static boolean isBetween(int num, int min, int max) {
+        return num >= min && num <= max;
+    }
+	
+	
+	/**
+     * Parses strings to a color if possible, and notifies the sender if it could not be parsed.
+     * @param redString - the red channel component to parse. Expect int in range 0-255.
+     * @param greenString - the green channel component to parse. Expect int in range 0-255.
+     * @param blueString - the blue channel component to parse. Expect int in range 0-255.
+     * @param sender - the commandSender to check and notify if failed
+     * @return If successful returns the range checked, parsed Color. If unsuccessful, returns null and notifies the sender.
+     */
+	public Color parseStringsToColor(String redString, String greenString, String blueString, CommandSender sender) {
+		
+        // Guard against argument casts not being valid (ie it's a string rather than a number)
+        int red;
+        int green;
+        int blue;
+        try {
+            red = Integer.parseInt(redString);
+            green = Integer.parseInt(greenString);
+            blue = Integer.parseInt(blueString);
+        }
+        catch (Exception e) {
+            sender.sendMessage(rgbInvalid);
+            return null;
+        }
+        
+        // Guard against bad color range values
+        if (!(isBetween(red, 0, 255) && isBetween(green, 0, 255) && isBetween(blue, 0, 255))) {
+            sender.sendMessage(rgbInvalid);
+            return null;
+        }
+        
+		return new Color(red, green, blue);
+	}
+
+	/**
+     * Checks if a command sender is not a player and notifies them if the command is for players only.
+     * @param sender - the commandSender to check and notify if failed
+     * @return If sender is a player returns false. Otherwise returns true.
+     */
+	public boolean senderIsNonPlayer(CommandSender sender) {
+		
+		if (!(sender instanceof Player)) {
+			sender.sendMessage(playerOnlyCommand);
+			return true;
+		}
+		return false;
+	}
+	
+	
+	
+
+    
+    
+	
+}

--- a/src/net/aegistudio/mpp/paint/GivePaintBottleCommand.java
+++ b/src/net/aegistudio/mpp/paint/GivePaintBottleCommand.java
@@ -3,7 +3,6 @@ package net.aegistudio.mpp.paint;
 
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.entity.Player;
 import net.aegistudio.mpp.CommandHandle;
 import net.aegistudio.mpp.MapPainting;
 import java.awt.Color;
@@ -15,24 +14,7 @@ import java.awt.Color;
  */
 public class GivePaintBottleCommand implements CommandHandle {
 	
-	private static final String redFormat 						= "\u00A74";
-	
     public static final String PERMISSION_NODE					= "mpp.command.give.player.paint.bottle";
-    public static final String PERMISSION_NODE_FAIL_TOKEN 		= "@mpp.common.permission.fail";
-    public static final String PERMISSION_NODE_FAIL_INVARIANT 	= redFormat + "You don't have permission to execute this command."; 
-    public String noPermission 									= PERMISSION_NODE_FAIL_INVARIANT;
-    
-    public static final String RGB_INVALID_TOKEN 				= "@mpp.common.rgb.invalid";
-    public static final String RGB_INVALID_INVARIANT 			= redFormat + "The RGB values provided were invalid."; 
-    public String rgbInvalid 									= RGB_INVALID_INVARIANT;
-    
-    public static final String PLAYER_OFFLINE_TOKEN 			= "@mpp.common.player.offline";
-    public static final String PLAYER_OFFLINE_INVARIANT 		= redFormat + " is offline."; 
-    public String playerOffline 								= PLAYER_OFFLINE_INVARIANT;
-    
-    public static final String INVENTORY_FULL_TOKEN 			= "@mpp.common.player.inventory.full";
-    public static final String INVENTORY_FULL_INVARIANT 		= redFormat + " has no free inventory space."; 
-    public String noInventory 									= INVENTORY_FULL_INVARIANT;
     
     public static final String USAGE_GUIDE_TOKEN 				= "@mpp.command.give.player.paint.bottle.usage";
     public static final String USAGE_GUIDE_INVARIANT 			= "Usage: /paint give <player> <red> <green> <blue>"; 
@@ -52,10 +34,6 @@ public class GivePaintBottleCommand implements CommandHandle {
      */
 	@Override
 	public void load(MapPainting plugin, ConfigurationSection config) throws Exception {
-		plugin.getLocale(PERMISSION_NODE_FAIL_TOKEN, PERMISSION_NODE_FAIL_INVARIANT, config);
-		plugin.getLocale(RGB_INVALID_TOKEN, RGB_INVALID_INVARIANT, config);
-		plugin.getLocale(PLAYER_OFFLINE_TOKEN, PLAYER_OFFLINE_INVARIANT, config);
-		plugin.getLocale(INVENTORY_FULL_TOKEN, INVENTORY_FULL_INVARIANT, config);
 		plugin.getLocale(USAGE_GUIDE_TOKEN, USAGE_GUIDE_INVARIANT, config);
 		plugin.getLocale(DESCRIPTION_TOKEN, DESCRIPTION_INVARIANT, config);
 		plugin.getLocale(SUCCESS_TOKEN, SUCCESS_INVARIANT, config);
@@ -86,79 +64,45 @@ public class GivePaintBottleCommand implements CommandHandle {
      * @param prefix - The command prefix /paint give.
      * @param sender - The command invoker, can be the console window.
      * @param args[] - Array of space separated arguments passed with the command
-     * @return true.
+     * @return if the command was successfully applied.
      */
 	@Override
 	public boolean handle(MapPainting plugin, String prefix, CommandSender sender, String[] args) {
     	
-    	// Guard against insufficient permissions to forcibly give a paint bottle
-        if (!sender.hasPermission(PERMISSION_NODE)) {
-            sender.sendMessage(noPermission);
-            return true;
+        if (plugin.utils.permissionCheckFails(PERMISSION_NODE, sender)) { 
+        	return false;
         }
         
-        // Guard against too few arguments to generate a bottle
-        if (args.length != 4) {
-            sender.sendMessage(usageGuide);
-            return true;
+        int expectedArguments = 4;
+        if (plugin.utils.commandHasIncorrectNumberOfArgs(expectedArguments, args, usageGuide, sender)) { 
+        	return false; 
+        };
+        
+        String playerName 	= args[0];
+        String red 			= args[1];
+        String green		= args[2];
+        String blue			= args[3];
+        
+        if (plugin.utils.playerIsOffline(playerName, sender)) {
+        	return false;
         }
         
-        // Guard against giving items to offline players
-        String playerName = args[0];
-        Player player = plugin.getServer().getPlayer(playerName);
-        if (player == null) {
-            sender.sendMessage(args[0] + playerOffline);
-            return true;
+        if (plugin.utils.playerHasNoInventorySpace(playerName, sender)) {
+        	return false;
         }
         
-        // Guard against no inventory space to receive the paint bottle
-        if (player.getInventory().firstEmpty() == -1){
-        	sender.sendMessage(playerName + noInventory);
-        	return true;
+        Color color = plugin.utils.parseStringsToColor(red, green, blue, sender);
+        if (color == null) {
+        	return false;
         }
         
-        // Guard against argument casts not being valid (ie it's a string rather than a number)
-        int red;
-        int green;
-        int blue;
-        try {
-            red = Integer.parseInt(args[1]);
-            green = Integer.parseInt(args[2]);
-            blue = Integer.parseInt(args[3]);
-        }
-        catch (Exception e) {
-            sender.sendMessage(rgbInvalid);
-            return true;
-        }
-        
-        // Guard against bad color range values
-        if (!(isBetween(red, 0, 255) && isBetween(green, 0, 255) && isBetween(blue, 0, 255))) {
-            sender.sendMessage(rgbInvalid);
-            return true;
-        }
-        
-        // Actually give the item
         PaintManager PM = plugin.m_paintManager;
-        Color color = new Color(red, green, blue);
-        player.getInventory().addItem(PM.getPaintBottle(color));
+        plugin.getServer().getPlayer(playerName).getInventory().addItem(PM.getPaintBottle(color));
         sender.sendMessage(playerName + success + PM.getColorName(color));
         
         return true;
 
 	}
-	
-	
-    /**
-     * Checks if a number is inside an expected range 
-     * @param num - int to check
-     * @param min - the lower boundary for success (inclusive)
-     * @param max - the upper boundary for success (inclusive)
-     * @return boolean - if the check value is between the min and max
-     */
-    private boolean isBetween(int num, int min, int max) {
-        return num >= min && num <= max;
-    }
-	
 	
 }
 

--- a/src/net/aegistudio/mpp/paint/PaintBottleRecipe.java
+++ b/src/net/aegistudio/mpp/paint/PaintBottleRecipe.java
@@ -41,7 +41,7 @@ public class PaintBottleRecipe implements Module {
     }
 
     @Override
-    public void load(MapPainting painting, ConfigurationSection section) throws Exception {
+    public void load(MapPainting painting, ConfigurationSection section) {
         this.painting = painting;
         for (int i = 2; i <= 9; ++i) {
         	

--- a/src/net/aegistudio/mpp/paint/PaintManager.java
+++ b/src/net/aegistudio/mpp/paint/PaintManager.java
@@ -214,7 +214,7 @@ public class PaintManager implements Module {
     /**
      * Initializes the paint bottle recipes
      */
-    public void InitializePaintBottleRecipe() throws Exception {
+    public void InitializePaintBottleRecipe() {
     	paintBottleRecipe = new PaintBottleRecipe();
         paintBottleRecipe.load(plugin, config);
     }
@@ -312,7 +312,7 @@ public class PaintManager implements Module {
     /**
      * Defines the names of colors of paint.
      */
-    public void DefineColorNames() throws Exception {
+    public void DefineColorNames() {
     	
     	// actually create the new map
     	colorNameMap = new HashMap <Color, String> ();


### PR DESCRIPTION
## What problem is this PR addressing
When beginning work on improving the mix paint bottle command it was identified that a significant number of checks share common logic implemented in different ways across the code base. This isn't ideal because often this common behavior can be improved more easily when it is centralized and can be made to behave more consistently and be more easily maintained.

## How is this PR addressing the problem
This PR:
- Moves common functions to a new utilities class instance attached to the main plugin object.
- Refactors common code methods out of GivePaintBottleCommand and implements them agnostically in utils where appropriate
- Localization for common methods is now performed in only one place for common code.
- Removed some dead comments

## What testing has been performed
- [x] Built and installed a release featuring the final change set
- [x] Retested both sets of commands to ensure they were still working. 
