### PR TITLE
Update rgb color token names

### DIFF
--- a/src/net/aegistudio/mpp/paint/PaintManager.java
+++ b/src/net/aegistudio/mpp/paint/PaintManager.java
@@ -248,7 +248,8 @@ public class PaintManager implements Module {
         // Color names
         for (Map.Entry<Color ,String> entry : colorNameMap.entrySet()) {
             Color color = entry.getKey();
-        	String token = "@lore.rgb." + color.getRed() + "." + color.getGreen() + "." + color.getBlue();
+            // we use underscores for the rgb code so it doesn't split it into a million config values
+        	String token = "@lore.colorname.rgb_" + color.getRed() + "_" + color.getGreen() + "_" + color.getBlue();
         	String localizedName = plugin.getLocale(token, entry.getValue(), config);
         	entry.setValue(localizedName);
         }


### PR DESCRIPTION
## What problem is this PR addressing
Changes made recently to add color names for "true" colors resulted in a large volume of config file garbage because it was splitting tokens between the rgb values due to the inclusion of ".".

## How is this PR addressing the problem
This PR modifies the color tokens used for name resolution so it generates a better flat list.

## What testing has been performed
- [x] Built and installed a release featuring the final change set and verified that token names resolve correctly after the changes
- [x] Verified that the config values are now clean and tidy 

