### PR TITLE
Remove Vault hard dependency

### DIFF
--- a/src/net/aegistudio/mpp/MapPainting.java
+++ b/src/net/aegistudio/mpp/MapPainting.java
@@ -13,7 +13,6 @@ import net.aegistudio.mpp.paint.PaintManager;
 import net.aegistudio.mpp.paint.GivePaintBottleCommand;
 import net.aegistudio.mpp.paint.MixPaintBottleCommand;
 import net.aegistudio.mpp.tool.*;
-import net.milkbowl.vault.economy.Economy;
 
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
@@ -23,7 +22,6 @@ import org.bukkit.configuration.Configuration;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.map.MinecraftFont;
-import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.java.JavaPlugin;
 import java.util.*;
 
@@ -50,21 +48,6 @@ public class MapPainting extends JavaPlugin {
     
     // declare utilities
     public Utils utils;
-    
-    // economy related variables
-    public static final String COST_CREATE = "costCreate";
-    public int costCreate = 1000;
-    public static final String COST_CLONE = "costClone";
-    public int costClone = 250;
-    public static final String COST_COPY = "costCopy";
-    public int costCopy = 500;
-    public static final String COST_RENAME = "costRename";
-    public int costRename = 100;
-    public static final String COST_PAINTBASIC = "costPaintBasic";
-    public int costPaintBasic = 250;
-    public static final String COST_PAINTRGB = "costPaintRGB";
-    public int costPaintRGB = 1000;
-    private static Economy econ;
     
     public static final String LISTING_TITLE = "listing";
     public String listing = "@composite.listing";
@@ -155,15 +138,6 @@ public class MapPainting extends JavaPlugin {
             } else {
                 m_configSection.set(COMMANDS_PER_PAGE, this.commandsPerPage);
             }
-
-            // Vault based economy hookup
-            if (!setupEconomy() ) {
-            	sendConsole("No Vault based economy found, command costs are disabled");
-                //return;
-            } else {
-            	sendConsole("Vault based economy found, enabling command costs");
-            	configureEconomy(m_configSection,this);
-            }
             
             this.fastTarget = this.getLocale(FAST_TARGET, this.fastTarget, m_configSection);
             
@@ -195,13 +169,6 @@ public class MapPainting extends JavaPlugin {
             }
             this.m_colorManager.load(this, config.getConfigurationSection(COLOR));
             
-            // foreign command management?
-            //this.m_foreignCanvasManager.reset();
-            //this.getServer().getServicesManager().register(PluginCanvasService.class, this.m_foreignCanvasManager, this, ServicePriority.Normal);
-            //this.m_foreignCommandManager = new PluginCommandManager(this);
-            //this.getServer().getServicesManager().register(PluginCommandService.class, this.m_foreignCommandManager, this, ServicePriority.Normal);
-            //this.getServer().getServicesManager().register(AssetService.class, this.m_assetManager, this, ServicePriority.Normal);
-            
             // configure canvases
             this.m_canvasManager = new CanvasManager();
             if (!config.contains(CANVAS)) {
@@ -209,37 +176,6 @@ public class MapPainting extends JavaPlugin {
             }
             this.m_canvasManager.load(this, config.getConfigurationSection(CANVAS));
             
-            /*
-             * USED TO CHECK IF OLD SHORT ISSUES STILL EXIST
-             * 
-             * 
-            try {
-            	
-            	for (int i=5; i<= 80000; i++){
-            		this.getServer().createMap(this.getServer().getWorlds().get(0));
-            		sendConsole( i  + " of 80000" );
-            	}
-            	
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-            */
-            
-            /*
-            
-            if (this.getServer().getWorld("PaintingStorage") == null) {
-                WorldCreator wc = new WorldCreator("PaintingStorage");
-                wc.environment(World.Environment.NORMAL);
-                wc.type(WorldType.FLAT);
-                wc.generatorSettings("2;0;1;");
-                wc.createWorld();
-                
-            }
-            
-            */
-
-            // save the configuration? why save when we load?
-            // SAVES ANY NEW VALUES INPUT BY CONFIG
             this.saveConfig();
             sendConsole("Configuration file saved");
 
@@ -267,75 +203,6 @@ public class MapPainting extends JavaPlugin {
     public void ackHistory(MapCanvasRegistry registry, CommandSender sender) {
         this.m_canvasManager.latest.put(sender.getName(), registry.name);
     }
-    
-    // Vault hooks
-    private boolean setupEconomy() {
-    	
-        if (getServer().getPluginManager().getPlugin("Vault") == null) {
-            return false;
-        }
-        
-        RegisteredServiceProvider<Economy> rsp = getServer().getServicesManager().getRegistration(Economy.class);
-        if (rsp == null) {
-            return false;
-        }
-        econ = rsp.getProvider();
-        return econ != null;
-    }
-    
-    public Economy getEconomy() {
-        return econ;
-    }
-    
-    private void configureEconomy(ConfigurationSection locale, MapPainting plugin) {
-    	
-    	// create values if they do not exist, load otherwise
-        if (locale.contains(COST_CREATE)) {
-            plugin.costCreate = locale.getInt(COST_CREATE);
-        } else {
-            locale.set(COST_CREATE, plugin.costCreate);
-        }
-        
-        // create values if they do not exist, load otherwise
-        if (locale.contains(COST_CLONE)) {
-            plugin.costClone = locale.getInt(COST_CLONE);
-        } else {
-            locale.set(COST_CLONE, plugin.costClone);
-        }
-
-        // create values if they do not exist, load otherwise
-        if (locale.contains(COST_COPY)) {
-            plugin.costCopy = locale.getInt(COST_COPY);
-        } else {
-            locale.set(COST_COPY, plugin.costCopy);
-        }
-        
-        // create values if they do not exist, load otherwise
-        if (locale.contains(COST_RENAME)) {
-            plugin.costRename = locale.getInt(COST_RENAME);
-        } else {
-            locale.set(COST_RENAME, plugin.costRename);
-        }
-        
-        // create values if they do not exist, load otherwise
-        if (locale.contains(COST_PAINTBASIC)) {
-            plugin.costPaintBasic = locale.getInt(COST_PAINTBASIC);
-        } else {
-            locale.set(COST_PAINTBASIC, plugin.costPaintBasic);
-        }
-        
-        // create values if they do not exist, load otherwise
-        if (locale.contains(COST_PAINTRGB)) {
-            plugin.costPaintRGB = locale.getInt(COST_PAINTRGB);
-        } else {
-            locale.set(COST_PAINTRGB, plugin.costPaintRGB);
-        }
-        
-        // update the plugins locale with updated config
-        plugin.m_configSection = locale;
-    	
-    }
-
     
     
     private void sendConsole(String message) {

--- a/src/net/aegistudio/mpp/canvas/Canvas.java
+++ b/src/net/aegistudio/mpp/canvas/Canvas.java
@@ -184,7 +184,6 @@ implements Cloneable {
         this.tickRunnable.cancel();
     }
 
-    @SuppressWarnings("deprecation")
 	public void render(MapView view, MapCanvas canvas, Player player) {
     	
         if (!this.hasViewed(player)) {

--- a/src/net/aegistudio/mpp/canvas/GiveCanvasCommand.java
+++ b/src/net/aegistudio/mpp/canvas/GiveCanvasCommand.java
@@ -3,8 +3,6 @@ package net.aegistudio.mpp.canvas;
 
 import net.aegistudio.mpp.ActualHandle;
 import net.aegistudio.mpp.MapPainting;
-import net.milkbowl.vault.economy.Economy;
-import net.milkbowl.vault.economy.EconomyResponse;
 
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.ConfigurationSection;
@@ -92,35 +90,6 @@ extends ActualHandle {
         	sender.sendMessage(this.needInv);
         	return true;
         }
-        
-        // check player can afford if economy is active
-    	Economy econ = plugin.getEconomy();    	
-    	int cost = 0;
-    	double balance = 0;
-
-    	// check balance
-    	if (econ != null){
-    		
-    		cost = plugin.costClone * quantity;
-    		balance = econ.getBalance(player);
-    		
-    		if (balance < cost) {
-    			sender.sendMessage(this.cantAfford.replace("$cost", String.valueOf(cost)));
-    			return true;
-    		}
-    		
-    	}
-    	
-    	// charge the player appropriately
-        if (econ != null){
-        	EconomyResponse transaction = econ.withdrawPlayer(player,  cost);
-        	if (transaction.transactionSuccess()) {
-        		sender.sendMessage(this.charged.replace("$cost", String.valueOf(cost)));
-        	} else {
-        		sender.sendMessage(this.cantAfford.replace("$cost", String.valueOf(cost)));
-        		return true;
-        	}
-    	}
         
         // actually give the item
         plugin.m_canvasManager.give((Player)sender, canvas, quantity);

--- a/src/net/aegistudio/mpp/canvas/MapCanvasRegistry.java
+++ b/src/net/aegistudio/mpp/canvas/MapCanvasRegistry.java
@@ -91,8 +91,6 @@ implements Module {
     	// the binding ID associated with the map?
     	this.binding = (int)canvas.getInt(BINDING);
     	
-    	plugin.getServer().getConsoleSender().sendMessage("attempting to bind " + binding.toString());
-    	
     	// the actual mapview (display surface?)
         this.view = plugin.getServer().getMap(this.binding);
         

--- a/src/net/aegistudio/mpp/canvas/RenameCommand.java
+++ b/src/net/aegistudio/mpp/canvas/RenameCommand.java
@@ -3,9 +3,6 @@ package net.aegistudio.mpp.canvas;
 
 import net.aegistudio.mpp.ActualHandle;
 import net.aegistudio.mpp.MapPainting;
-import net.milkbowl.vault.economy.Economy;
-import net.milkbowl.vault.economy.EconomyResponse;
-
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
@@ -23,10 +20,6 @@ public class RenameCommand extends ActualHandle {
 	public String noRenamePermission;
 	public static final String SUCCESSFULLY_RENAME = "successfullyRename";
 	public String successfullyRename;
-	public static final String CANT_AFFORD = "cantAfford";
-	public String cantAfford;
-	public static final String CHARGED = "charged";
-	public String charged;
 
 	public RenameCommand() {
 		this.description = "@rename.description";
@@ -36,8 +29,6 @@ public class RenameCommand extends ActualHandle {
 		this.notHolding = "@rename.notHolding";
 		this.noRenamePermission = "@rename.noRenamePermission";
 		this.successfullyRename = "@rename.successfullyRename";
-		this.cantAfford = "@rename.cantAfford $cost";
-		this.charged = "@rename.charged $cost";
 	}
 
 	@Override
@@ -98,34 +89,6 @@ public class RenameCommand extends ActualHandle {
 			sender.sendMessage(this.canvasAlreadyExist.replace("$canvasName", newname));
 			return true;
 		}
-        
-        // check player can afford if economy is active
-    	Economy econ = plugin.getEconomy();    	
-    	int cost = 0;
-    	double balance = 0;
-
-    	if (econ != null){
-    		
-    		cost = plugin.costRename;
-    		balance = econ.getBalance(player);
-    		
-    		if (balance < cost) {
-    			sender.sendMessage(this.cantAfford.replace("$cost", String.valueOf(cost)));
-    			return true;
-    		}
-    		
-    	}
-    	
-    	// charge the player appropriately
-        if (econ != null){
-        	EconomyResponse transaction = econ.withdrawPlayer(player,  cost);
-        	if (transaction.transactionSuccess()) {
-        		sender.sendMessage(this.charged.replace("$cost", String.valueOf(cost)));
-        	} else {
-        		sender.sendMessage(this.cantAfford.replace("$cost", String.valueOf(cost)));
-        		return true;
-        	}
-    	}
 		
 		String oldname = oldcanvas.name;
 		plugin.m_canvasManager.nameCanvasMap.put(newname, oldcanvas);
@@ -152,7 +115,5 @@ public class RenameCommand extends ActualHandle {
 		this.notHolding = painting.getLocale(NOT_HOLDING, this.notHolding, section);
 		this.noRenamePermission = painting.getLocale(NO_RENAME_PERMISSION, this.noRenamePermission, section);
 		this.successfullyRename = painting.getLocale(SUCCESSFULLY_RENAME, this.successfullyRename, section);
-		this.cantAfford = painting.getLocale(CANT_AFFORD, this.cantAfford, section);
-		this.charged = painting.getLocale(CHARGED, this.charged, section);
 	}
 }

--- a/src/net/aegistudio/mpp/factory/CloneCreateCommand.java
+++ b/src/net/aegistudio/mpp/factory/CloneCreateCommand.java
@@ -4,27 +4,15 @@ package net.aegistudio.mpp.factory;
 import net.aegistudio.mpp.MapPainting;
 import net.aegistudio.mpp.canvas.Canvas;
 import net.aegistudio.mpp.canvas.MapCanvasRegistry;
-import net.milkbowl.vault.economy.Economy;
-import net.milkbowl.vault.economy.EconomyResponse;
-
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.entity.Player;
 
-public class CloneCreateCommand
-extends BaseCreateCommand {
+public class CloneCreateCommand extends BaseCreateCommand {
+	
     public static final String CLONED_UNSPECIFIED = "clonedUnspecified";
     public String clonedUnspecified;
     public static final String CANVAS_NOT_EXISTS = "canvasNotExists";
     public String canvasNotExists;
-    public static final String NEED_INV = "needInv";
-    public String needInv;
-    public static final String CANT_AFFORD = "cantAfford";
-    public String cantAfford;
-    public static final String CHARGED = "charged";
-    public String charged;
-    public static final String NO_PERMISSION = "noPermission";
-    public String noPermission;
     
 
     public CloneCreateCommand() {
@@ -32,77 +20,42 @@ extends BaseCreateCommand {
         this.paramList = "<cloned>";
         this.clonedUnspecified = "@create.clone.clonedUnspecified";
         this.canvasNotExists = "@create.clone.canvasNotExists";
-        this.needInv = "@create.clone.needInv";
-        this.cantAfford = "@create.clone.cantAfford $cost";
-        this.charged = "@create.clone.charged $cost";
-        this.noPermission = "@create.clone.noPermission $canvasName";
     }
 
     @Override
     protected Canvas create(MapPainting plugin, CommandSender sender, String[] arguments) {
         
     	// check sender has sufficient perms
-    	if (!sender.hasPermission("mpp.create.clone")) {
-            sender.sendMessage(plugin.m_commandCreateHandler.noCreatePermission);
+    	if (plugin.utils.permissionCheckFails("mpp.create.clone", sender)) {
             return null;
         }
     	
     	// check sender is a player
-    	if (!(sender instanceof Player)) {
-    		sender.sendMessage(plugin.m_commandCreateHandler.onlyPlayer);
+    	if (plugin.utils.senderIsNonPlayer(sender)) {
     		return null;
-    	}
-    	
-    	Player player = (Player) sender;
-    	
-    	// check player can afford if economy is active
-    	Economy econ = plugin.getEconomy();
-    	int cost = 0;
-    	double balance = 0;
-
-    	// check if player can afford
-    	if (econ != null){
-    		cost = plugin.costCopy;
-    		balance = econ.getBalance(player);
-    		
-    		if (balance < cost) {
-    			sender.sendMessage(this.cantAfford.replace("$cost", String.valueOf(cost)));
-    			return null;
-    		}
-    		
     	}
     	
     	if (arguments.length == 0) {
             sender.sendMessage(this.clonedUnspecified);
             return null;
         }
-        
+    	
     	String name = arguments[0];
-        MapCanvasRegistry entry = plugin.getCanvas(name, sender);
+        MapCanvasRegistry mapData = plugin.getCanvas(name, sender);
         
-        
-        if (entry == null) {
+        if (mapData == null) {
             sender.sendMessage(this.canvasNotExists.replace("$canvasName", name));
             return null;
         }
         
      // check player has sufficient rights to copy the canvas
-        if (!entry.hasPermission(sender, "give")) {
-            sender.sendMessage(this.noPermission.replace("$canvasName", name));
+        if (!mapData.hasPermission(sender, "give")) {
+            //sender.sendMessage(this.noPermission.replace("$canvasName", name));
+        	sender.sendMessage("You have insufficient rights to copy canvas {canvasName}");
             return null;
         }
         
-        // ECON COST OF CREATING THE CANVAS
-        if (econ != null){
-        	EconomyResponse transaction = econ.withdrawPlayer(player,  cost);
-        	if (transaction.transactionSuccess()) {
-        		sender.sendMessage(this.charged.replace("$cost", String.valueOf(cost)));
-        	} else {
-        		sender.sendMessage(this.cantAfford.replace("$cost", String.valueOf(cost)));
-        	}
-    	}
-        
-        return entry.canvas.clone();
+        return mapData.canvas.clone();
     }
 
     @Override

--- a/src/net/aegistudio/mpp/factory/NormalCreateCommand.java
+++ b/src/net/aegistudio/mpp/factory/NormalCreateCommand.java
@@ -5,9 +5,6 @@ import java.awt.Color;
 import net.aegistudio.mpp.MapPainting;
 import net.aegistudio.mpp.canvas.BufferedCanvas;
 import net.aegistudio.mpp.canvas.Canvas;
-import net.milkbowl.vault.economy.Economy;
-import net.milkbowl.vault.economy.EconomyResponse;
-
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
@@ -20,10 +17,6 @@ public class NormalCreateCommand extends BaseCreateCommand {
     public String outOfRange;
     public static final String NEED_INV = "needInv";
     public String needInv;
-    public static final String CHARGED = "charged";
-    public String charged;
-    public static final String CANT_AFFORD = "cantAfford";
-    public String cantAfford;
     
 
     public NormalCreateCommand() {
@@ -32,8 +25,6 @@ public class NormalCreateCommand extends BaseCreateCommand {
         this.invalidFormat = "@create.normal.invalidFormat";
         this.outOfRange = "@create.normal.outOfRange";
         this.needInv = "@create.normal.needInv";
-        this.charged = "@create.normal.charged $cost";
-        this.cantAfford = "@create.normal.cantAfford $cost";
     }
 
     @Override
@@ -49,23 +40,6 @@ public class NormalCreateCommand extends BaseCreateCommand {
     	if (!(sender instanceof Player)) {
     		sender.sendMessage(plugin.m_commandCreateHandler.onlyPlayer);
     		return null;
-    	}
-    	Player player = (Player) sender;
-    	
-    	// check player can afford if economy is active
-    	Economy econ = plugin.getEconomy();
-    	int cost = 0;
-    	double balance = 0;
-
-    	if (econ != null){
-    		cost = plugin.costCreate;
-    		balance = econ.getBalance(player);
-    		
-    		if (balance < cost) {
-    			sender.sendMessage(this.cantAfford.replace("$cost", String.valueOf(cost)));
-    			return null;
-    		}
-    		
     	}
     	
     	// check if size argument is supplied
@@ -98,16 +72,6 @@ public class NormalCreateCommand extends BaseCreateCommand {
             }
         }
         
-        // ECON COST OF CREATING THE CANVAS
-        if (econ != null){
-        	EconomyResponse transaction = econ.withdrawPlayer(player,  cost);
-        	if (transaction.transactionSuccess()) {
-        		sender.sendMessage(this.charged.replace("$cost", String.valueOf(cost)));
-        	} else {
-        		sender.sendMessage(this.cantAfford.replace("$cost", String.valueOf(cost)));
-        	}
-    	}
-        
         // actually return the canvas to the player        
         byte canvasColor = (byte)plugin.m_canvasManager.color.getIndex(color);
         BufferedCanvas canvas = new BufferedCanvas(plugin);
@@ -127,8 +91,6 @@ public class NormalCreateCommand extends BaseCreateCommand {
         this.invalidFormat = plugin.getLocale(INVALID_FORMAT, this.invalidFormat, section);
         this.outOfRange = plugin.getLocale(OUT_OF_RANGE, this.outOfRange, section);
         this.needInv = plugin.getLocale(NEED_INV, this.needInv, section);
-        this.charged = plugin.getLocale(CHARGED, this.charged, section);
-        this.cantAfford = plugin.getLocale(CANT_AFFORD, this.cantAfford, section);
     }
 
 }

--- a/src/net/aegistudio/mpp/paint/MixPaintBottleCommand.java
+++ b/src/net/aegistudio/mpp/paint/MixPaintBottleCommand.java
@@ -1,8 +1,6 @@
 package net.aegistudio.mpp.paint;
 
 import net.aegistudio.mpp.MapPainting;
-import net.milkbowl.vault.economy.Economy;
-import net.milkbowl.vault.economy.EconomyResponse;
 import net.aegistudio.mpp.CommandHandle;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.ConfigurationSection;
@@ -18,19 +16,7 @@ import java.awt.Color;
 public class MixPaintBottleCommand implements CommandHandle {
 	
     public static final String PERMISSION_NODE					= "mpp.command.mix.paint.bottle";
-	
-	public static final String ONLY_PLAYER = "onlyPlayer";
-	public String onlyPlayer;
-	public static final String NO_PIGMENT_PERMISSION = "noPermission";
-	public String noPigmentPermission;
-	public static final String INVALID_FORMAT = "invalidFormat";
-	public String invalidFormat;
-	public static final String CHARGED = "charged";
-	public String charged;
-	public static final String CANT_AFFORD = "cantAfford";
-	public String cantAfford;
-	public static final String NEED_INV = "needInv";
-	public String needInv;
+
 	public static final String GAVE_PIGMENT = "gavePigment $name";
 	public String gavePigment;
 	
@@ -39,12 +25,6 @@ public class MixPaintBottleCommand implements CommandHandle {
 	
 	public MixPaintBottleCommand() {
 		this.description = "@pigment.description";
-		this.onlyPlayer = "@pigment.onlyPlayer";
-		this.noPigmentPermission = "@pigment.noPigmentPermission";
-		this.invalidFormat = "@pigment.invalidFormat";
-		this.charged = "@pigment.charged $cost";
-		this.cantAfford = "@pigment.charged $cost";
-		this.needInv = "@pigment.needInv";
 		this.gavePigment = "@pigment.gavePigment $name";
 	}
 
@@ -54,10 +34,7 @@ public class MixPaintBottleCommand implements CommandHandle {
      */
 	@Override
 	public void load(MapPainting plugin, ConfigurationSection section) throws Exception {
-		this.onlyPlayer = plugin.getLocale(ONLY_PLAYER, this.onlyPlayer, section);
-		this.noPigmentPermission = plugin.getLocale(NO_PIGMENT_PERMISSION, this.noPigmentPermission, section);
-		this.invalidFormat = plugin.getLocale(INVALID_FORMAT, this.invalidFormat, section);
-		this.charged = plugin.getLocale(CHARGED, this.charged, section);
+		
 	}
 
 	
@@ -113,33 +90,6 @@ public class MixPaintBottleCommand implements CommandHandle {
 		if (plugin.utils.playerHasNoInventorySpace(player.getName(), sender)) {
 			return true;
 		}
-        
-        // check player can afford if economy is active
-    	Economy econ = plugin.getEconomy();    	
-    	int cost = 0;
-    	double balance = 0;
-    	
-		cost = plugin.costPaintRGB;
-
-    	// check balance
-    	if (econ != null){	
-    		balance = econ.getBalance(player);
-    		if (balance < cost) {
-    			sender.sendMessage(this.cantAfford.replace("$cost", String.valueOf(cost)));
-    			return true;
-    		}
-    	}
-    	
-    	// charge the player appropriately
-        if (econ != null){
-        	EconomyResponse transaction = econ.withdrawPlayer(player,  cost);
-        	if (transaction.transactionSuccess()) {
-        		sender.sendMessage(this.charged.replace("$cost", String.valueOf(cost)));
-        	} else {
-        		sender.sendMessage(this.cantAfford.replace("$cost", String.valueOf(cost)));
-        		return true;
-        	}
-    	}
 
         // Actually generate the item and give it to the player
 		ItemStack item = plugin.m_paintManager.getPaintBottle(mixResult);

--- a/src/net/aegistudio/mpp/paint/PaintBucketListener.java
+++ b/src/net/aegistudio/mpp/paint/PaintBucketListener.java
@@ -3,6 +3,7 @@ package net.aegistudio.mpp.paint;
 
 import java.awt.Color;
 import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -14,13 +15,22 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.ShapelessRecipe;
 import org.bukkit.potion.PotionEffectType;
 
+import net.aegistudio.mpp.MapPainting;
+
 /**
  * Defines event listeners related to paint bucket recipe crafting (...and consumption)
  * Canvas interactions are not managed here.
  */
 public class PaintBucketListener implements Listener {
     
+	// String localization
+	
+    public static final String BUCKET_DRINK_TOKEN 		= "@paint.bucket.drink";
+    public static final String BUCKET_DRINK_INVARIANT 	= "GLUG, GLUG, GLUG!"; 
+    public String drinkPaintBucket 						= BUCKET_DRINK_INVARIANT;
+	
 	private PaintManager PM;
+	
     PotionEffectType[] rewards = new PotionEffectType[]{PotionEffectType.BLINDNESS, PotionEffectType.CONFUSION, PotionEffectType.HARM, PotionEffectType.HUNGER, PotionEffectType.POISON, PotionEffectType.WEAKNESS};
 
     
@@ -29,8 +39,13 @@ public class PaintBucketListener implements Listener {
      * Defines event listeners related to paint bucket recipe crafting (...and consumption)
      * Canvas interactions are not managed here.
      */
-    public PaintBucketListener(PaintManager paintManager) {
-        PM = paintManager;
+    public PaintBucketListener(MapPainting plugin) {
+        PM = plugin.m_paintManager;
+        
+        // Localize paint bucket related strings
+        ConfigurationSection config = plugin.getConfig();
+        this.drinkPaintBucket = plugin.getLocale(BUCKET_DRINK_TOKEN, BUCKET_DRINK_INVARIANT, config);
+        
     }
 
     
@@ -140,7 +155,7 @@ public class PaintBucketListener implements Listener {
         }
         
         this.rewards[(int)((double)this.rewards.length * Math.random())].createEffect(2000, 1).apply((LivingEntity)e.getPlayer());
-        e.getPlayer().sendMessage(this.PM.paintBucketRecipe.drinkPaintBucket);
+        e.getPlayer().sendMessage(this.drinkPaintBucket);
         ItemStack item = new ItemStack(Material.BUCKET, 1);
         e.getPlayer().setItemInHand(item);
         e.setCancelled(true);

--- a/src/net/aegistudio/mpp/paint/PaintBucketRecipe.java
+++ b/src/net/aegistudio/mpp/paint/PaintBucketRecipe.java
@@ -14,17 +14,10 @@ import org.bukkit.inventory.ShapelessRecipe;
 import org.bukkit.plugin.Plugin;
 
 
+/**
+ * Responsible for definition, registration and configuration of the paint bucket crafting recipe.
+ */
 public class PaintBucketRecipe implements Module {
-	
-	// String localization
-	
-    public static final String BUCKET_DRINK_TOKEN 		= "@palette.bucket.drink";
-    public static final String BUCKET_DRINK_INVARIANT 	= "GLUG, GLUG, GLUG!"; 
-    public String drinkPaintBucket 						= BUCKET_DRINK_INVARIANT;
-    
-    public static final String BUCKET_FILLED_TOKEN 		= "@palette.bucket.filled";
-    public static final String BUCKET_FILLED_INVARIANT 	= "Filled Paint Bucket"; 
-    public String fillBucket 							= BUCKET_FILLED_INVARIANT;
     
     // Quick reference to the main plugin for ease of accessing other classes
     public MapPainting plugin;
@@ -67,7 +60,7 @@ public class PaintBucketRecipe implements Module {
      * Adds a paint bucket listener that handles interactions related to paint buckets
      */
     public void RegisterPaintBucketListener() {
-    	PaintBucketListener listener = new PaintBucketListener(plugin.m_paintManager);
+    	PaintBucketListener listener = new PaintBucketListener(plugin);
         plugin.getServer().getPluginManager().registerEvents((Listener)listener, (Plugin)plugin);
     }
     
@@ -104,10 +97,6 @@ public class PaintBucketRecipe implements Module {
         
     	// Update the uninstantiated plugin reference
     	this.plugin = plugin;
-    	
-        // Localize paint bucket related strings
-        this.drinkPaintBucket = plugin.getLocale(BUCKET_DRINK_TOKEN, BUCKET_DRINK_INVARIANT, config);
-        this.fillBucket = plugin.getLocale(BUCKET_FILLED_TOKEN, BUCKET_FILLED_INVARIANT, config);
         
         AddPaintBucketRecipe();
         RegisterPaintBucketListener();

--- a/src/net/aegistudio/mpp/paint/PaintManager.java
+++ b/src/net/aegistudio/mpp/paint/PaintManager.java
@@ -62,7 +62,9 @@ public class PaintManager implements Module {
 	public String whiteFormat 	= "\u00A7f";
 	public String randomFormat 	= "\u00A7k";
 	
-	// Define names of colors
+	/** 
+	 * Map of "true" map colors to human friendly display name colors
+	 */
 	HashMap <Color, String> colorNameMap;
     
     


### PR DESCRIPTION
## What problem is this PR addressing
Painting shouldn't be locked behind a paywall. The current model (optionally) relies on servers running economy modules, but the ultimate vision for the direction of the plugin I have is more of a "mix paint from ingredients" as this is a more engaging gameplay loop than just typing a single command.

## How is this PR addressing the problem
This PR:
- Addresses the early steps towards implementing the above model, removing the economy implementations and dependencies. 
- Mans the overall plugin is now dependent only on WorldGuard and WorldEdit plugins as hard dependencies.
- Removes all usages of economy related values and their related 

## Relevant design decisions
While it is understood that some servers do want the economy costs for working with paintings (as a gold sink) ultimately I feel that decoupling the implementation to use native mechanics yields a better game-play experience for users. Economy users can always remap the command structure to alternatives and add the charges to their implementation, or fork this updated repo and revert the simple changes contained herein.

## What testing has been performed
- [x] Built and installed a release featuring the final change set
- [x] Verified impacted / modified commands still resolve correctly.

